### PR TITLE
feat: Add request latency and query count logging filter

### DIFF
--- a/filmeet/src/main/java/com/ureca/filmeet/global/config/HibernateConfig.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/global/config/HibernateConfig.java
@@ -1,0 +1,21 @@
+package com.ureca.filmeet.global.config;
+
+import com.ureca.filmeet.global.filter.QueryInspector;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.cfg.AvailableSettings;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class HibernateConfig {
+
+    private final QueryInspector queryInspector;
+
+    @Bean
+    public HibernatePropertiesCustomizer hibernatePropertiesCustomizer() {
+        return hibernateProperties ->
+                hibernateProperties.put(AvailableSettings.STATEMENT_INSPECTOR, queryInspector);
+    }
+}

--- a/filmeet/src/main/java/com/ureca/filmeet/global/filter/LatencyLoggingFilter.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/global/filter/LatencyLoggingFilter.java
@@ -1,0 +1,40 @@
+package com.ureca.filmeet.global.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LatencyLoggingFilter extends OncePerRequestFilter {
+
+    private final LatencyRecorder latencyRecorder;
+    private final QueryInspector queryInspector;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        latencyRecorder.start();
+
+        filterChain.doFilter(request, response);
+
+        double latencyForSeconds = latencyRecorder.getLatencyForSeconds();
+        int queryCount = queryInspector.getQueryCount();
+        String requestURI = request.getRequestURI();
+
+        log.info("Latency : {}s, Query count : {}, Request URI : {}", latencyForSeconds, queryCount, requestURI);
+
+        MDC.clear();
+    }
+}

--- a/filmeet/src/main/java/com/ureca/filmeet/global/filter/LatencyRecorder.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/global/filter/LatencyRecorder.java
@@ -1,0 +1,22 @@
+package com.ureca.filmeet.global.filter;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class LatencyRecorder {
+
+    private final ThreadLocal<Long> threadLocal = new ThreadLocal<>();
+
+    public void start() {
+        threadLocal.set(System.currentTimeMillis());
+    }
+
+    public double getLatencyForSeconds() {
+        long start = threadLocal.get();
+        long end = System.currentTimeMillis();
+
+        threadLocal.remove();
+
+        return (end - start) / 1000d;
+    }
+}

--- a/filmeet/src/main/java/com/ureca/filmeet/global/filter/QueryCounter.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/global/filter/QueryCounter.java
@@ -1,0 +1,19 @@
+package com.ureca.filmeet.global.filter;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+@Component
+@RequestScope
+public class QueryCounter {
+
+    private int count = 0;
+
+    public void increase() {
+        count++;
+    }
+
+    public int getCount() {
+        return count;
+    }
+}

--- a/filmeet/src/main/java/com/ureca/filmeet/global/filter/QueryInspector.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/global/filter/QueryInspector.java
@@ -1,0 +1,30 @@
+package com.ureca.filmeet.global.filter;
+
+import lombok.RequiredArgsConstructor;
+import org.hibernate.resource.jdbc.spi.StatementInspector;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+
+@Component
+@RequiredArgsConstructor
+public class QueryInspector implements StatementInspector {
+
+    private final QueryCounter queryCounter;
+
+    @Override
+    public String inspect(String sql) {
+        if (isInRequestScope()) {
+            queryCounter.increase();
+        }
+
+        return sql;
+    }
+
+    private boolean isInRequestScope() {
+        return RequestContextHolder.getRequestAttributes() != null;
+    }
+
+    public int getQueryCount() {
+        return queryCounter.getCount();
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Feat/FM-19 -> dev

## PR 설명
쿼리의 latency와 발생 쿼리 개수를 확인하는 기능을 추가했습니다.

## ✅ 완료한 기능 명세

- [x]  LatencyLoggingFilter 구현
- [x] QueryInspector 구현

## 📸 스크린샷
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

## 고민과 해결과정
