### PR TITLE
faet: 유저 엔티티 변경 및 취향 업데이트 API

### DIFF
--- a/filmeet/src/main/java/com/ureca/filmeet/domain/auth/controller/command/AuthCommandController.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/domain/auth/controller/command/AuthCommandController.java
@@ -1,24 +1,45 @@
 package com.ureca.filmeet.domain.auth.controller.command;
 
+import com.ureca.filmeet.domain.auth.dto.request.LoginRequest;
+import com.ureca.filmeet.domain.auth.dto.response.TokenResponse;
+import com.ureca.filmeet.domain.auth.service.IdPwAuthenticationService;
 import com.ureca.filmeet.domain.user.entity.User;
 import com.ureca.filmeet.global.common.dto.ApiResponse;
 import com.ureca.filmeet.global.util.jwt.TokenService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
+@Slf4j
 public class AuthCommandController {
 
+    private final IdPwAuthenticationService idPwAuthenticationService;
     private final TokenService tokenService;
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody LoginRequest request) {
+        TokenResponse tokens = idPwAuthenticationService.authenticate(request);
+        return ApiResponse.ok(tokens);
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refreshAccessToken(@RequestHeader("Authorization") String refreshToken) {
+        // "Bearer " 접두사 제거
+        String token = refreshToken.replace("Bearer ", "");
+
+        // 새 Access/Refresh Token 생성
+        TokenResponse tokens = tokenService.refreshAccessToken(token);
+        return ApiResponse.ok(tokens);
+    }
 
     @PostMapping("/logout")
     public ResponseEntity<?> logout(@AuthenticationPrincipal User user) {
+        log.info("user = {}", user);
         tokenService.invalidateTokens(user.getUsername());
         return ApiResponse.okWithoutData();
     }

--- a/filmeet/src/main/java/com/ureca/filmeet/domain/auth/controller/query/AuthQueryController.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/domain/auth/controller/query/AuthQueryController.java
@@ -1,36 +1,12 @@
 package com.ureca.filmeet.domain.auth.controller.query;
 
-import com.ureca.filmeet.domain.auth.dto.request.LoginRequest;
-import com.ureca.filmeet.domain.auth.dto.response.TokenResponse;
-import com.ureca.filmeet.domain.auth.service.IdPwAuthenticationService;
-import com.ureca.filmeet.global.common.dto.ApiResponse;
-import com.ureca.filmeet.global.util.jwt.TokenService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthQueryController {
 
-    private final IdPwAuthenticationService idPwAuthenticationService;
-    private final TokenService tokenService;
-
-    @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody LoginRequest request) {
-        TokenResponse tokens = idPwAuthenticationService.authenticate(request);
-        return ApiResponse.ok(tokens);
-    }
-
-    @PostMapping("/refresh")
-    public ResponseEntity<?> refreshAccessToken(@RequestHeader("Authorization") String refreshToken) {
-        // "Bearer " 접두사 제거
-        String token = refreshToken.replace("Bearer ", "");
-
-        // 새 Access/Refresh Token 생성
-        TokenResponse tokens = tokenService.refreshAccessToken(token);
-
-        return ApiResponse.ok(tokens);
-    }
 }

--- a/filmeet/src/main/java/com/ureca/filmeet/domain/movie/controller/query/MovieQueryController.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/domain/movie/controller/query/MovieQueryController.java
@@ -1,34 +1,22 @@
 package com.ureca.filmeet.domain.movie.controller.query;
 
 import com.ureca.filmeet.domain.genre.entity.enums.GenreType;
-import com.ureca.filmeet.domain.movie.dto.response.MovieDetailResponse;
-import com.ureca.filmeet.domain.movie.dto.response.MovieSearchByTitleResponse;
-import com.ureca.filmeet.domain.movie.dto.response.MoviesRankingsResponse;
-import com.ureca.filmeet.domain.movie.dto.response.MoviesResponse;
-import com.ureca.filmeet.domain.movie.dto.response.MoviesSearchByGenreResponse;
-import com.ureca.filmeet.domain.movie.dto.response.RecommendationMoviesResponse;
-import com.ureca.filmeet.domain.movie.dto.response.UpcomingMoviesResponse;
+import com.ureca.filmeet.domain.movie.dto.response.*;
 import com.ureca.filmeet.domain.movie.repository.BoxOfficeCacheStore;
-import com.ureca.filmeet.domain.movie.service.query.MovieQueryService;
-import com.ureca.filmeet.domain.movie.service.query.MovieRankingsQueryService;
-import com.ureca.filmeet.domain.movie.service.query.MovieRecommendationQueryService;
-import com.ureca.filmeet.domain.movie.service.query.MovieUpcomingQueryService;
-import com.ureca.filmeet.domain.movie.service.query.MoviesSearchService;
+import com.ureca.filmeet.domain.movie.service.query.*;
 import com.ureca.filmeet.domain.user.entity.User;
 import com.ureca.filmeet.global.common.dto.ApiResponse;
 import com.ureca.filmeet.global.common.dto.SliceResponseDto;
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/movies")
@@ -42,6 +30,7 @@ public class MovieQueryController {
     private final MovieRankingsQueryService movieRankingsQueryService;
     private final MovieRecommendationQueryService movieRecommendationQueryService;
 
+    @PreAuthorize("true")
     @GetMapping("/upcoming")
     public ResponseEntity<ApiResponse<SliceResponseDto<UpcomingMoviesResponse>>> getUpcomingMovies(
             @RequestParam(defaultValue = "0") int page,

--- a/filmeet/src/main/java/com/ureca/filmeet/domain/user/controller/command/UserCommandController.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/domain/user/controller/command/UserCommandController.java
@@ -1,15 +1,15 @@
 package com.ureca.filmeet.domain.user.controller.command;
 
+import com.ureca.filmeet.domain.user.dto.request.UpdatePreferenceRequest;
 import com.ureca.filmeet.domain.user.dto.request.UserSignUpRequest;
 import com.ureca.filmeet.domain.user.dto.response.UserDetailResponse;
+import com.ureca.filmeet.domain.user.entity.User;
 import com.ureca.filmeet.domain.user.service.command.UserCommandService;
 import com.ureca.filmeet.global.common.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 
 @RestController
@@ -18,9 +18,24 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserCommandController {
     private final UserCommandService userCommandService;
 
+
     @PostMapping("/signup")
     public ResponseEntity<?> signUpUser(@RequestBody UserSignUpRequest request) {
         UserDetailResponse userDetailResponse = userCommandService.signUp(request);
         return ApiResponse.created(userDetailResponse);
+    }
+
+    @PostMapping("/update/profile")
+    public ResponseEntity<?> updateProfileImage(@RequestParam String profileImage,
+                                                @AuthenticationPrincipal User user) {
+        userCommandService.UpdateProfileImage(profileImage, user);
+        return ApiResponse.okWithoutData();
+    }
+
+    @PostMapping("/update/preference")
+    public ResponseEntity<?> updatePreference(@RequestBody UpdatePreferenceRequest request,
+                                              @AuthenticationPrincipal User user) {
+        userCommandService.updatePreference(request, user);
+        return ApiResponse.okWithoutData();
     }
 }

--- a/filmeet/src/main/java/com/ureca/filmeet/domain/user/dto/request/UpdatePreferenceRequest.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/domain/user/dto/request/UpdatePreferenceRequest.java
@@ -1,0 +1,10 @@
+package com.ureca.filmeet.domain.user.dto.request;
+
+import java.util.List;
+
+public record UpdatePreferenceRequest(
+        String mbti,
+        Integer age,
+        List<Long> genreIds
+) {
+}

--- a/filmeet/src/main/java/com/ureca/filmeet/domain/user/entity/User.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/domain/user/entity/User.java
@@ -40,6 +40,11 @@ public class User extends BaseTimeEntity {
     @Column(length = 20)
     private String nickname;
 
+    private Integer age = 0;
+
+    @Column(length = 4)
+    private String mbti;
+
     private String profileImage;
 
     @OneToMany(mappedBy = "user")
@@ -67,5 +72,14 @@ public class User extends BaseTimeEntity {
         this.provider = provider;
         this.nickname = nickname;
         this.profileImage = profileImage;
+    }
+
+    public void updateProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+    }
+
+    public void updatePreference(String mbti, Integer age) {
+        this.mbti = mbti;
+        this.age = age;
     }
 }

--- a/filmeet/src/main/java/com/ureca/filmeet/domain/user/service/command/UserCommandService.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/domain/user/service/command/UserCommandService.java
@@ -2,14 +2,18 @@ package com.ureca.filmeet.domain.user.service.command;
 
 import com.ureca.filmeet.domain.genre.entity.Genre;
 import com.ureca.filmeet.domain.genre.entity.GenreScore;
+import com.ureca.filmeet.domain.genre.entity.enums.GenreScoreAction;
 import com.ureca.filmeet.domain.genre.repository.GenreRepository;
 import com.ureca.filmeet.domain.genre.repository.GenreScoreBulkRepository;
+import com.ureca.filmeet.domain.genre.repository.GenreScoreRepository;
+import com.ureca.filmeet.domain.user.dto.request.UpdatePreferenceRequest;
 import com.ureca.filmeet.domain.user.dto.request.UserSignUpRequest;
 import com.ureca.filmeet.domain.user.dto.response.UserDetailResponse;
 import com.ureca.filmeet.domain.user.entity.Provider;
 import com.ureca.filmeet.domain.user.entity.Role;
 import com.ureca.filmeet.domain.user.entity.User;
 import com.ureca.filmeet.domain.user.repository.UserRepository;
+import com.ureca.filmeet.domain.user.service.query.UserQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -25,6 +29,8 @@ public class UserCommandService {
     private final PasswordEncoder passwordEncoder;
     private final GenreRepository genreRepository;
     private final GenreScoreBulkRepository genreScoreBulkRepository;
+    private final GenreScoreRepository genreScoreRepository;
+    private final UserQueryService userQueryService;
 
     public UserDetailResponse signUp(UserSignUpRequest request) {
         if (userRepository.existsByUsername(request.username())) {
@@ -49,6 +55,7 @@ public class UserCommandService {
         );
     }
 
+    @Transactional
     public User createTemporaryUser(String providerId, String name, Provider provider, String profileImage) {
         User tempUser = User.builder()
                 .username(providerId)
@@ -62,6 +69,23 @@ public class UserCommandService {
         initializeGenreScores(savedUser);
 
         return savedUser;
+    }
+
+    @Transactional
+    public void UpdateProfileImage(String profileImage, User loginUser) {
+        User user = userQueryService.findById(loginUser.getId());
+        user.updateProfileImage(profileImage);
+    }
+
+    @Transactional
+    public void updatePreference(UpdatePreferenceRequest request, User loginUser) {
+        User user = userQueryService.findById(loginUser.getId());
+        user.updatePreference(request.mbti(), request.age());
+
+        genreScoreRepository.bulkUpdateGenreScores(
+                GenreScoreAction.PREFERRED_GENRE.getWeight(),
+                request.genreIds(),
+                user.getId());
     }
 
     private void initializeGenreScores(User user) {

--- a/filmeet/src/main/java/com/ureca/filmeet/domain/user/service/query/UserQueryService.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/domain/user/service/query/UserQueryService.java
@@ -11,6 +11,11 @@ import org.springframework.stereotype.Service;
 public class UserQueryService {
     private final UserRepository userRepository;
 
+    public User findById(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+    }
+
     public User findByUsername(String username) {
         return userRepository.findByUsername(username)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found by username: " + username));

--- a/filmeet/src/main/java/com/ureca/filmeet/global/config/SecurityConfig.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/global/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import com.ureca.filmeet.global.security.OAuth2AuthenticationSuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -68,10 +69,31 @@ public class SecurityConfig {
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                         .accessDeniedHandler(customAccessDeniedHandler))
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/actuator/health").permitAll() // 먼저 선언
-                        .requestMatchers("/images/**", "/users/signup", "/auth/**", "/users/check-username", "/swagger",
-                                "/swagger-ui.html", "/swagger-ui/**", "/api-docs", "/api-docs/**", "/v3/api-docs/**")
+                        // 기본 허용 경로
+                        .requestMatchers("/actuator/health").permitAll()
+                        .requestMatchers("/images/**",
+                                "/users/signup",
+                                "/users/check-username",
+                                "/auth/login",
+                                "/auth/refresh")
                         .permitAll()
+
+                        // 리뷰 관련 경로 허용
+                        .requestMatchers(HttpMethod.GET, "/reviews/movies/*").permitAll() // 영화 리뷰 목록 조회
+                        .requestMatchers(HttpMethod.GET, "/reviews/*").permitAll()       // 리뷰 상세 조회
+                        .requestMatchers(HttpMethod.GET, "/reviews/users")
+                        .permitAll() // 지금 뜨는 리뷰 조회 (쿼리 파라미터는 컨트롤러에서 검증)
+
+                        // 영화 관련 경로 허용
+                        .requestMatchers(HttpMethod.GET, "/movies/upcoming").permitAll()        // 공개 예정작
+                        .requestMatchers(HttpMethod.GET, "/movies/boxoffice").permitAll()       // 박스오피스 순위
+                        .requestMatchers(HttpMethod.GET, "/movies/rankings").permitAll()        // TOP 10 영화
+                        .requestMatchers(HttpMethod.GET, "/movies/*").permitAll()               // 영화 상세 조회
+                        .requestMatchers(HttpMethod.GET, "/movies/search/genre").permitAll()    // 장르 검색
+                        .requestMatchers(HttpMethod.GET, "/movies/search/title").permitAll()    // 제목 검색
+
+                        // 컬렉션 관련 경로 허용
+                        .requestMatchers(HttpMethod.GET, "/collections/search/title").permitAll() // 컬렉션 제목 검색
                         .anyRequest().authenticated()
                 );
 

--- a/filmeet/src/main/java/com/ureca/filmeet/global/security/JwtAuthenticationEntryPoint.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/global/security/JwtAuthenticationEntryPoint.java
@@ -25,6 +25,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
             throws IOException, ServletException {
         log.error("Exception in JwtAuthenticationEntryPoint: {}", authException.getMessage());
+        log.error("getCause = {}", authException.getCause());
         resolver.resolveException(request, response, null, authException);
     }
 }

--- a/filmeet/src/main/java/com/ureca/filmeet/infra/s3/config/S3Config.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/infra/s3/config/S3Config.java
@@ -1,18 +1,31 @@
 package com.ureca.filmeet.infra.s3.config;
 
-import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import com.amazonaws.regions.Regions;
 
 @Configuration
 public class S3Config {
 
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
     @Bean
-    public AmazonS3 amazonS3() {
-        return AmazonS3ClientBuilder.standard()
-                .withRegion(Regions.AP_NORTHEAST_2) // 서울 리전 설정
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
                 .build();
     }
 }

--- a/filmeet/src/main/java/com/ureca/filmeet/infra/s3/dto/S3UploadRequest.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/infra/s3/dto/S3UploadRequest.java
@@ -8,7 +8,7 @@ import java.util.List;
 public record S3UploadRequest(
         MultipartFile file
 ) {
-    private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png", "webp");
+    private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png", "webp", "svg");
     private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
     public void validate() throws FileUploadException {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Feat/FM-91 -> dev

## PR 설명
유저 도메인에 나이, mbti 필드 추가
선호 장르, 나이, mbti를 업데이트하는 API 개발

## ✅ 완료한 기능 명세

- [x] 이슈 제목: [FEATURE] '기능 내용 상세'
- [x] Assignees, Label을 붙여주세요.



## 고민과 해결과정
