### PR TITLE
refactor: 관리자 영화 페이징 조회 응답 필드 추가

### DIFF
--- a/filmeet/src/main/java/com/ureca/filmeet/domain/admin/controller/query/AdminQueryController.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/domain/admin/controller/query/AdminQueryController.java
@@ -37,8 +37,9 @@ public class AdminQueryController {
 
     @GetMapping("/movies")
     public ResponseEntity<?> getMovies(@RequestParam(defaultValue = "0") int page,
-                                       @RequestParam(defaultValue = "10") int size) {
-        Page<AdminMovieResponse> movieResponses = movieQueryService.getMovies(page, size);
+                                       @RequestParam(defaultValue = "10") int size,
+                                       @RequestParam(required = false) String query) {
+        Page<AdminMovieResponse> movieResponses = movieQueryService.getMovies(page, size, query);
         return ResponseEntity.ok(movieResponses);
     }
 

--- a/filmeet/src/main/java/com/ureca/filmeet/domain/admin/dto/response/AdminMovieResponse.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/domain/admin/dto/response/AdminMovieResponse.java
@@ -1,9 +1,11 @@
 package com.ureca.filmeet.domain.admin.dto.response;
 
+import com.ureca.filmeet.domain.genre.entity.enums.GenreType;
 import com.ureca.filmeet.domain.movie.entity.Gallery;
 import com.ureca.filmeet.domain.movie.entity.Movie;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 
 public record AdminMovieResponse(
@@ -12,6 +14,8 @@ public record AdminMovieResponse(
         String posterUrl,
         Integer likeCounts,
         BigDecimal averageRating,
+        List<GenreType> genreTypes,
+        LocalDate releaseDate,
         List<String> galleries
 ) {
     public static AdminMovieResponse fromEntity(Movie movie) {
@@ -21,6 +25,10 @@ public record AdminMovieResponse(
                 movie.getPosterUrl(),
                 movie.getLikeCounts() != null ? movie.getLikeCounts() : 0,
                 movie.getAverageRating() != null ? movie.getAverageRating() : BigDecimal.ZERO,
+                movie.getMovieGenres().stream()
+                        .map(movieGenre -> movieGenre.getGenre().getGenreType())
+                        .toList(),
+                movie.getReleaseDate(),
                 movie.getGalleries().stream()
                         .map(Gallery::getImageUrl)
                         .toList()

--- a/filmeet/src/main/java/com/ureca/filmeet/domain/movie/repository/MovieRepository.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/domain/movie/repository/MovieRepository.java
@@ -2,8 +2,10 @@ package com.ureca.filmeet.domain.movie.repository;
 
 import com.ureca.filmeet.domain.movie.dto.response.MoviesRoundmatchResponse;
 import com.ureca.filmeet.domain.movie.entity.Movie;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -133,22 +135,29 @@ public interface MovieRepository extends JpaRepository<Movie, Long>, MovieCustom
     List<Movie> findMoviesWithGenres(@Param("movies") List<Movie> movies);
 
     @Query("""
-        SELECT new com.ureca.filmeet.domain.movie.dto.response.MoviesRoundmatchResponse(
-            m.id,
-            m.title,
-            m.posterUrl,
-            m.likeCounts,
-            CAST(COALESCE(SUM(r.commentCounts), 0) AS int),
-            m.ratingCounts
-        )
-        FROM Movie m
-        INNER JOIN MovieGenre mg ON m.id = mg.movie.id
-        INNER JOIN MovieGenre targetMg ON targetMg.movie.id = :movieId AND mg.genre.id = targetMg.genre.id
-        LEFT JOIN Review r ON r.movie.id = m.id
-        WHERE m.id != :movieId
-        GROUP BY m.id, m.title, m.posterUrl, m.likeCounts, m.ratingCounts
-        ORDER BY COUNT(mg.genre.id) DESC, m.likeCounts DESC
-        limit 6
-    """)
+                SELECT new com.ureca.filmeet.domain.movie.dto.response.MoviesRoundmatchResponse(
+                    m.id,
+                    m.title,
+                    m.posterUrl,
+                    m.likeCounts,
+                    CAST(COALESCE(SUM(r.commentCounts), 0) AS int),
+                    m.ratingCounts
+                )
+                FROM Movie m
+                INNER JOIN MovieGenre mg ON m.id = mg.movie.id
+                INNER JOIN MovieGenre targetMg ON targetMg.movie.id = :movieId AND mg.genre.id = targetMg.genre.id
+                LEFT JOIN Review r ON r.movie.id = m.id
+                WHERE m.id != :movieId
+                GROUP BY m.id, m.title, m.posterUrl, m.likeCounts, m.ratingCounts
+                ORDER BY COUNT(mg.genre.id) DESC, m.likeCounts DESC
+                limit 6
+            """)
     List<MoviesRoundmatchResponse> findSimilarMoviesByGenre(@Param("movieId") Long movieId);
+
+    @EntityGraph(attributePaths = {"movieGenres.genre"})
+    Page<Movie> findAll(Pageable pageable);
+
+    @EntityGraph(attributePaths = {"movieGenres.genre"})
+    Page<Movie> findByTitleContainingIgnoreCase(String title, Pageable pageable);
+
 }

--- a/filmeet/src/main/java/com/ureca/filmeet/domain/movie/service/query/MovieQueryService.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/domain/movie/service/query/MovieQueryService.java
@@ -56,9 +56,17 @@ public class MovieQueryService {
         return movieRepository.findById(movieId).orElseThrow(MovieNotFoundException::new);
     }
 
-    public Page<AdminMovieResponse> getMovies(int page, int size) {
+    public Page<AdminMovieResponse> getMovies(int page, int size, String query) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "releaseDate"));
-        Page<Movie> moviePage = movieRepository.findAll(pageable);
+
+        Page<Movie> moviePage;
+        if (query == null || query.isBlank()) {
+            // 검색어가 없는 경우 전체 조회
+            moviePage = movieRepository.findAll(pageable);
+        } else {
+            // 검색어가 있는 경우 제목 기준 검색
+            moviePage = movieRepository.findByTitleContainingIgnoreCase(query, pageable);
+        }
 
         return moviePage.map(AdminMovieResponse::fromEntity);
     }

--- a/filmeet/src/main/resources/application.yml
+++ b/filmeet/src/main/resources/application.yml
@@ -34,7 +34,7 @@ spring:
               - openid
               - profile
               - email
-            redirect-uri: "{baseUrl}/login/oauth2/code/google"
+            redirect-uri: "https://filmeet.net/api/login/oauth2/code/google"
             authorization-grant-type: authorization_code
             client-name: Google
             client-authentication-method: client_secret_post
@@ -46,7 +46,7 @@ spring:
               - name
               - email
               - profile_image
-            redirect-uri: "{baseUrl}/login/oauth2/code/naver"
+            redirect-uri: "https://filmeet.net/api/login/oauth2/code/naver"
             authorization-grant-type: authorization_code
             client-name: Naver
             client-authentication-method: client_secret_post
@@ -94,8 +94,6 @@ server:
   port: 8080
   servlet:
     context-path: /api
-  forward-headers-strategy: native
-
 ---
 
 # Dev 환경 설정


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Feat/FM-119/login -> dev

## PR 설명
관리자 영화 페이징 조회 응답 필드 추가, N+1 문제 고려

## ✅ 완료한 기능 명세

- [x] 이슈 제목: [FEATURE] '기능 내용 상세'
- [ ] Assignees, Label을 붙여주세요.

## 📸 스크린샷
``` json
{
    "content": [
        {
            "id": 10,
            "title": "거미숲",
            "posterUrl": "http://file.koreafilm.or.kr/thm/02/00/03/55/tn_DPK06200A.jpg",
            "likeCounts": 0,
            "averageRating": 0,
            "genreTypes": [
                "CRIME",
                "DRAMA",
                "MYSTERY",
                "THRILLER"
            ],
            "releaseDate": "2004-09-03",
            "galleries": [
                "http://file.koreafilm.or.kr/thm/02/00/03/55/tn_DPK06200A.jpg",
                "http://file.koreafilm.or.kr/thm/02/00/01/11/tn_DPK003332.jpg",
                "http://file.koreafilm.or.kr/thm/02/00/01/11/tn_DPK003330.jpg",
                "http://file.koreafilm.or.kr/thm/02/00/01/11/tn_DPK003331.jpg"
            ]
        }
    ],
    "pageable": {
        "pageNumber": 0,
        "pageSize": 10,
        "sort": {
            "empty": false,
            "unsorted": false,
            "sorted": true
        },
        "offset": 0,
        "paged": true,
        "unpaged": false
    },
    "totalPages": 1,
    "totalElements": 1,
    "last": true,
    "size": 10,
    "number": 0,
    "sort": {
        "empty": false,
        "unsorted": false,
        "sorted": true
    },
    "numberOfElements": 1,
    "first": true,
    "empty": false
}
```

## 고민과 해결과정
Response에 Genre를 담기 위해서 N+1 문제가 발생하는 상황
``` java
public static AdminMovieResponse fromEntity(Movie movie) {
        return new AdminMovieResponse(
                movie.getId(),
                movie.getTitle(),
                movie.getPosterUrl(),
                movie.getLikeCounts() != null ? movie.getLikeCounts() : 0,
                movie.getAverageRating() != null ? movie.getAverageRating() : BigDecimal.ZERO,
                movie.getMovieGenres().stream()
                        .map(movieGenre -> movieGenre.getGenre().getGenreType())
                        .toList(),
                movie.getReleaseDate(),
                movie.getGalleries().stream()
                        .map(Gallery::getImageUrl)
                        .toList()
        );
    }
```

고려한 사항
❌ Fetch Join은 페이징과 결합 시 복잡성이 증가하고, JPQL 작성 및 유지보수가 어려움
❌ Batch Size 설정은 N+1 문제를 완화하지만 완전히 해결하지 못하고, 각 엔티티별 설정 관리가 필요
❌ DTO 직접 쿼리 매핑은 가장 강력한 방법이 될 수 있으나, 이 경우 JPQL 또는 Native Query를 통해 DTO로 바로 매핑하는 로직을 추가로 작성해야 하므로 개발 및 유지보수 비용이 증가

선택한 해결 방법
- EntityGraph
페이징과의 궁합:
EntityGraph는 JPA 표준 스펙으로, Spring Data JPA에서도 페이징 쿼리와 자연스럽게 결합되어 작동. 즉, 별도의 JPQL 작성 없이도 페이징 쿼리에 엔티티 그래프를 적용할 수 있음

유지보수성과 가독성:
Fetch Join을 사용하면 JPQL 쿼리를 직접 작성해야 하고, 쿼리가 복잡해지면 유지보수가 어려워짐. 반면에 @EntityGraph를 사용하면 기존의 메서드 쿼리에 간단한 어노테이션 추가만으로 연관 관계를 명시적으로 로딩할 수 있어 코드 가독성과 유지보수성이 향상

확장성:
엔티티 그래프를 통해 특정 조회 시점에 필요한 연관 엔티티만을 로딩할 수 있음. 필요에 따라 다른 그래프를 정의할 수 있으므로, 용도에 따라 다양한 그래프를 적용할 수 있음. 이는 향후 요구사항 변경에 유연하게 대응할 수 있음

``` java
    @EntityGraph(attributePaths = {"movieGenres.genre"})
    Page<Movie> findAll(Pageable pageable);

    @EntityGraph(attributePaths = {"movieGenres.genre"})
    Page<Movie> findByTitleContainingIgnoreCase(String title, Pageable pageable);
```
