### PR TITLE
fix: 박스오피스 순위 리스트 조회 API 오류 해결

### DIFF
--- a/filmeet/src/main/java/com/ureca/filmeet/domain/movie/repository/MovieRepository.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/domain/movie/repository/MovieRepository.java
@@ -169,4 +169,7 @@ public interface MovieRepository extends JpaRepository<Movie, Long>, MovieCustom
     Slice<Movie> findMoviesBy(
             Pageable pageable
     );
+
+    @Query("SELECT m FROM Movie m WHERE m.title IN :titles")
+    List<Movie> findMoviesByTitles(@Param("titles") List<String> titles);
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Fix/FM-146 -> dev

## PR 설명
DB로부터 제목으로 영화를 가져오는 부분에 문제가 발생해 캐시에 데이터가 담기지 않았습니다.
그래서 조회 쿼리를 수정하여 로컬 캐시에 박스오피스 순위 데이터가 담기지 않은 문제를 해결했습니다.
기존 박스오피스 순위 리스트 조회 스케줄러가 오전 8시에 한번 발생하게 했지만 정각마다 발생하도록 수정했습니다.
데이터를 가져오는 부분에 상세한 정보를 확인하기 위해 로그를 추가했습니다.

## ✅ 완료한 기능 명세

- [x] 이슈 제목: [FEATURE] '기능 내용 상세'
- [ ] Assignees, Label을 붙여주세요.

## 📸 스크린샷
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

## 고민과 해결과정
