### PR TITLE
refactor: limit 쿼리가 나가지 않는 오류를 임시적으로 N+1 이 나가는 쿼리로 대체

### DIFF
--- a/filmeet/src/main/java/com/ureca/filmeet/domain/admin/dto/response/AdminMovieResponse.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/domain/admin/dto/response/AdminMovieResponse.java
@@ -1,7 +1,6 @@
 package com.ureca.filmeet.domain.admin.dto.response;
 
 import com.ureca.filmeet.domain.genre.entity.enums.GenreType;
-import com.ureca.filmeet.domain.movie.entity.Gallery;
 import com.ureca.filmeet.domain.movie.entity.Movie;
 
 import java.math.BigDecimal;
@@ -15,8 +14,8 @@ public record AdminMovieResponse(
         Integer likeCounts,
         BigDecimal averageRating,
         List<GenreType> genreTypes,
-        LocalDate releaseDate,
-        List<String> galleries
+        LocalDate releaseDate
+//        List<String> galleries
 ) {
     public static AdminMovieResponse fromEntity(Movie movie) {
         return new AdminMovieResponse(
@@ -28,10 +27,10 @@ public record AdminMovieResponse(
                 movie.getMovieGenres().stream()
                         .map(movieGenre -> movieGenre.getGenre().getGenreType())
                         .toList(),
-                movie.getReleaseDate(),
-                movie.getGalleries().stream()
-                        .map(Gallery::getImageUrl)
-                        .toList()
+                movie.getReleaseDate()
+//                movie.getGalleries().stream()
+//                        .map(Gallery::getImageUrl)
+//                        .toList()
         );
     }
 }

--- a/filmeet/src/main/java/com/ureca/filmeet/domain/movie/repository/MovieRepository.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/domain/movie/repository/MovieRepository.java
@@ -2,16 +2,16 @@ package com.ureca.filmeet.domain.movie.repository;
 
 import com.ureca.filmeet.domain.movie.dto.response.MoviesRoundmatchResponse;
 import com.ureca.filmeet.domain.movie.entity.Movie;
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 
 public interface MovieRepository extends JpaRepository<Movie, Long>, MovieCustomRepository {
 
@@ -162,10 +162,10 @@ public interface MovieRepository extends JpaRepository<Movie, Long>, MovieCustom
             """)
     List<MoviesRoundmatchResponse> findSimilarMoviesByGenre(@Param("movieId") Long movieId);
 
-    @EntityGraph(attributePaths = {"movieGenres.genre"})
+    //    @EntityGraph(attributePaths = {"movieGenres.genre"})
     Page<Movie> findAll(Pageable pageable);
 
-    @EntityGraph(attributePaths = {"movieGenres.genre"})
+    //    @EntityGraph(attributePaths = {"movieGenres.genre"})
     Page<Movie> findByTitleContainingIgnoreCase(String title, Pageable pageable);
 
     @Query(


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
Refactor/FM-156 -> dev

## PR 설명
영화 페이징 조회 쿼리가 Entiity Graph 설정으로 인해 limit 쿼리가 발생하지 않는 문제가 있음
해당 어노테이션 주석처리하고 N+1 쿼리가 더 성능이 좋은 것을 확인하고 임시로 조치

## ✅ 완료한 기능 명세

- [x] 이슈 제목: [refactor: 어드민 조회 기능 성능 향상#156](https://github.com/LG-URECA-FINAL-TEAM8/filmeet-backend/issues/156)
- [x] Assignees, Label을 붙여주세요.

## 📸 스크린샷
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

## 고민과 해결과정
```
    //    @EntityGraph(attributePaths = {"movieGenres.genre"})
    Page<Movie> findAll(Pageable pageable);

    //    @EntityGraph(attributePaths = {"movieGenres.genre"})
    Page<Movie> findByTitleContainingIgnoreCase(String title, Pageable pageable);
```