### PR TITLE
refactor: 영화 상세 조회 쿼리 수정

### DIFF
--- a/filmeet/src/main/java/com/ureca/filmeet/domain/movie/dto/response/MovieDetailResponse.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/domain/movie/dto/response/MovieDetailResponse.java
@@ -16,9 +16,7 @@ public record MovieDetailResponse(
         Integer likeCounts,
         Integer ratingCounts,
         BigDecimal averageRating,
-        boolean isLiked,
-        MyMovieReview myMovieReview,
-        MyMovieRating myMovieRating,
+        UserMovieInteractionResponse userMovieInteractionResponse,
         List<String> countries,
         List<GenreType> genres,
         List<PersonnelInfoResponse> personnels,
@@ -26,12 +24,14 @@ public record MovieDetailResponse(
         List<RatingDistributionResponse> ratingDistribution
 ) {
 
-    public static MovieDetailResponse from(Movie movie, boolean isLiked, MyMovieReview myMovieReview,
-                                           MyMovieRating myMovieRating,
-                                           List<String> countries, List<GenreType> genres,
-                                           List<PersonnelInfoResponse> personnels,
-                                           List<String> galleryImages,
-                                           List<RatingDistributionResponse> ratingDistribution) {
+    public static MovieDetailResponse from(
+            Movie movie,
+            UserMovieInteractionResponse userMovieInteractionResponse,
+            List<String> countries, List<GenreType> genres,
+            List<PersonnelInfoResponse> personnels,
+            List<String> galleryImages,
+            List<RatingDistributionResponse> ratingDistribution
+    ) {
 
         return new MovieDetailResponse(
                 movie.getId(),
@@ -43,9 +43,7 @@ public record MovieDetailResponse(
                 movie.getLikeCounts(),
                 movie.getRatingCounts(),
                 movie.getAverageRating(),
-                isLiked,
-                myMovieReview,
-                myMovieRating,
+                userMovieInteractionResponse,
                 countries,
                 genres,
                 personnels,

--- a/filmeet/src/main/java/com/ureca/filmeet/domain/movie/dto/response/UserMovieInteractionResponse.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/domain/movie/dto/response/UserMovieInteractionResponse.java
@@ -1,0 +1,13 @@
+package com.ureca.filmeet.domain.movie.dto.response;
+
+import java.math.BigDecimal;
+
+public record UserMovieInteractionResponse(
+        Long movieRatingId,
+        BigDecimal ratingScore,
+        Long reviewId,
+        String content,
+        String userProfileImage,
+        Boolean isLiked
+) {
+}

--- a/filmeet/src/main/java/com/ureca/filmeet/domain/movie/repository/MovieRepository.java
+++ b/filmeet/src/main/java/com/ureca/filmeet/domain/movie/repository/MovieRepository.java
@@ -1,6 +1,7 @@
 package com.ureca.filmeet.domain.movie.repository;
 
 import com.ureca.filmeet.domain.movie.dto.response.MoviesRoundmatchResponse;
+import com.ureca.filmeet.domain.movie.dto.response.UserMovieInteractionResponse;
 import com.ureca.filmeet.domain.movie.entity.Movie;
 import com.ureca.filmeet.domain.movie.repository.querydsl.MovieCustomRepository;
 import java.time.LocalDate;
@@ -185,4 +186,25 @@ public interface MovieRepository extends JpaRepository<Movie, Long>, MovieCustom
 
     @Query("SELECT m FROM Movie m WHERE m.title IN :titles AND m.isDeleted = false ")
     List<Movie> findMoviesByTitles(@Param("titles") List<String> titles);
+
+    @Query("""
+                SELECT new com.ureca.filmeet.domain.movie.dto.response.UserMovieInteractionResponse(
+                    mr.id,
+                    mr.ratingScore,
+                    r.id,
+                    r.content,
+                    u.profileImage,
+                    CASE WHEN ml.id IS NOT NULL THEN true ELSE false END
+                )
+                FROM Movie m
+                LEFT JOIN MovieRatings mr ON mr.movie.id = m.id AND mr.user.id = :userId
+                LEFT JOIN Review r ON r.movie.id = m.id AND r.user.id = :userId AND r.isDeleted = false
+                LEFT JOIN User u ON u.id = :userId
+                LEFT JOIN MovieLikes ml ON ml.movie.id = m.id AND ml.user.id = :userId
+                WHERE m.id = :movieId AND m.isDeleted = false
+            """)
+    Optional<UserMovieInteractionResponse> findUserMovieReviewAndRating(
+            @Param("movieId") Long movieId,
+            @Param("userId") Long userId
+    );
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 리픽터링

### 반영 브랜치
Refactor/FM-203 -> dev

## PR 설명
영화 상세 조회에서 기존에는 본인이 작성한 리뷰, 평점, 좋아요 여부를 각각의 쿼리로 데이터를 가져왔습니다.
이러한 데이터들을 한번에 가져오도록 쿼리를 수정하여 발생 쿼리의 개수를 9 -> 6으로 줄였습니다.

## ✅ 완료한 기능 명세
- [x] 영화 상세 조회 본인이 작성한 리뷰, 평점, 좋아요 여부 한번에 조회

## 📸 스크린샷
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

## 고민과 해결과정
